### PR TITLE
Added spin animation utility

### DIFF
--- a/examples/utilities/animations.html
+++ b/examples/utilities/animations.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Animations
+category: _utilities
+---
+
+<p> Spin:
+  <span class="icon--spinner icon--large u-animation--spin"></span>
+</p>

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -14,6 +14,7 @@
 'patterns_tooltips';
 
 // Import Util files, if needed
+@import 'utilities_animations';
 
 @mixin vanilla-dashboard-theme {
 
@@ -26,4 +27,5 @@
   @include theme-p-tooltips;
 
   // Include Util mixins, if needed
+  @include theme-animations;
 }

--- a/scss/_utilities_animations.scss
+++ b/scss/_utilities_animations.scss
@@ -1,0 +1,16 @@
+/// Animations
+@mixin theme-animations {
+  .u-animation--spin {
+    animation: spin map-get($animation-duration, sleepy) infinite linear !important;
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+}


### PR DESCRIPTION
## Done

Added spin animation utility.

## QA

- Checkout this branch
- Run server ./run
- Go to animation examples page: http://0.0.0.0:8102/vanilla-dashboard-theme/examples/utilities/animations/
- Watch it spin

Or watch it spin on demo server directly: http://vanilla-dashboard-theme-pr-27.run.demo.haus/vanilla-dashboard-theme/examples/utilities/animations/

Spinner in different sizes:
Light background: http://vanilla-dashboard-theme-pr-27.run.demo.haus/vanilla-dashboard-theme/examples/base/icons/icons-light/
Dark background: http://vanilla-dashboard-theme-pr-27.run.demo.haus/vanilla-dashboard-theme/examples/base/icons/icons-dark/

## Details

Fixes #11 

## Screenshots

![spin](https://user-images.githubusercontent.com/83575/28369224-436b1252-6c97-11e7-9243-0bba332b9f21.gif)

